### PR TITLE
Move encoding to top of SCSS file as per standards. #3

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -1,7 +1,7 @@
+@charset "utf-8";
 ---
 # Main SASS File
 ---
-@charset "utf-8";
 
 @import "vendor/wfp-ui-kit/wfpui";
 @import "vars";


### PR DESCRIPTION
As per the [CSS encoding spec](http://www.w3.org/TR/2013/WD-css-syntax-3-20130919/#charset-rule), `@charset "utf-8";` needs to be the very first rule.